### PR TITLE
URL Cleanup

### DIFF
--- a/Greenhouse/GHEventSessionDetailsContent.html
+++ b/Greenhouse/GHEventSessionDetailsContent.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
     
     <head>

--- a/Greenhouse/GHInfoContent.html
+++ b/Greenhouse/GHInfoContent.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 
 <head>

--- a/Greenhouse/GHTweetsViewController.m
+++ b/Greenhouse/GHTweetsViewController.m
@@ -21,7 +21,7 @@
 //
 //
 //  Based on Apple's LazyTableImages
-//  http://developer.apple.com/iphone/library/samplecode/LazyTableImages/Introduction/Intro.html
+//  https://developer.apple.com/iphone/library/samplecode/LazyTableImages/Introduction/Intro.html
 //
 
 #import "GHTweetsViewController.h"

--- a/Greenhouse/GHVenueDetailsContent.html
+++ b/Greenhouse/GHVenueDetailsContent.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
     
     <head>

--- a/Greenhouse/GHVenueDetailsViewController.m
+++ b/Greenhouse/GHVenueDetailsViewController.m
@@ -57,7 +57,7 @@
     if (venue)
     {
         NSString *encodedAddress = [venue.postalAddress stringByURLEncoding];
-        NSString *urlString = [[NSString alloc] initWithFormat:@"http://maps.google.com/maps?q=%@", encodedAddress];
+        NSString *urlString = [[NSString alloc] initWithFormat:@"https://maps.google.com/maps?q=%@", encodedAddress];
         NSURL *url = [NSURL URLWithString:urlString];
         [[UIApplication sharedApplication] openURL:url];
     }

--- a/Greenhouse/Greenhouse-Info.plist
+++ b/Greenhouse/Greenhouse-Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>

--- a/Greenhouse/Greenhouse.xcdatamodeld/.xccurrentversion
+++ b/Greenhouse/Greenhouse.xcdatamodeld/.xccurrentversion
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>

--- a/Greenhouse/NSString+Encoding.m
+++ b/Greenhouse/NSString+Encoding.m
@@ -19,7 +19,7 @@
 //
 //  Created by Roy Clarkson on 9/23/10.
 //
-//  Code and solution discussed at http://stackoverflow.com/questions/803676/encode-nsstring-for-xml-html/1933237
+//  Code and solution discussed at https://stackoverflow.com/questions/803676/encode-nsstring-for-xml-html/1933237
 //
 
 #import "NSString+Encoding.h"

--- a/Greenhouse/Settings.bundle/Root.plist
+++ b/Greenhouse/Settings.bundle/Root.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>StringsTable</key>

--- a/GreenhouseApplicationTests/GreenhouseApplicationTests-Info.plist
+++ b/GreenhouseApplicationTests/GreenhouseApplicationTests-Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>

--- a/GreenhouseLogicTests/GreenhouseLogicTests-Info.plist
+++ b/GreenhouseLogicTests/GreenhouseLogicTests-Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>

--- a/GreenhouseLogicTests/UIColor_CustomColorsTests.m
+++ b/GreenhouseLogicTests/UIColor_CustomColorsTests.m
@@ -49,7 +49,7 @@
 #pragma mark Helpers
 
 // As answered by Dave DeLong in the following StackOverflow question
-// http://stackoverflow.com/questions/3805177/how-to-convert-hex-rgb-color-codes-to-uicolor
+// https://stackoverflow.com/questions/3805177/how-to-convert-hex-rgb-color-codes-to-uicolor
 - (UIColor *)colorFromHexString:(NSString *)hexString
 {
     NSString *cleanString = [hexString stringByReplacingOccurrencesOfString:@"#" withString:@""];


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://iphoneincubator.com/blog/debugging/the-evolution-of-a-replacement-for-nslog (200) with 1 occurrences could not be migrated:  
   ([https](https://iphoneincubator.com/blog/debugging/the-evolution-of-a-replacement-for-nslog) result AnnotatedConnectException).
* [ ] http://www.openradar.me/8121374 (200) with 1 occurrences could not be migrated:  
   ([https](https://www.openradar.me/8121374) result ClosedChannelException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd (ReadTimeoutException) with 3 occurrences migrated to:  
  https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd ([https](https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd) result SSLException).
* [ ] http://developer.apple.com/iphone/library/samplecode/LazyTableImages/Introduction/Intro.html (301) with 1 occurrences migrated to:  
  https://developer.apple.com/iphone/library/samplecode/LazyTableImages/Introduction/Intro.html ([https](https://developer.apple.com/iphone/library/samplecode/LazyTableImages/Introduction/Intro.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://stackoverflow.com/questions/3805177/how-to-convert-hex-rgb-color-codes-to-uicolor with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/3805177/how-to-convert-hex-rgb-color-codes-to-uicolor ([https](https://stackoverflow.com/questions/3805177/how-to-convert-hex-rgb-color-codes-to-uicolor) result 200).
* [ ] http://stackoverflow.com/questions/803676/encode-nsstring-for-xml-html/1933237 with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/803676/encode-nsstring-for-xml-html/1933237 ([https](https://stackoverflow.com/questions/803676/encode-nsstring-for-xml-html/1933237) result 200).
* [ ] http://www.apple.com/DTDs/PropertyList-1.0.dtd with 5 occurrences migrated to:  
  https://www.apple.com/DTDs/PropertyList-1.0.dtd ([https](https://www.apple.com/DTDs/PropertyList-1.0.dtd) result 200).
* [ ] http://maps.google.com/maps?q=%@ with 1 occurrences migrated to:  
  https://maps.google.com/maps?q=%@ ([https](https://maps.google.com/maps?q=%@) result 302).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1:8080/greenhouse/events with 1 occurrences
* http://127.0.0.1:8080/greenhouse/oauth/token with 2 occurrences
* http://localhost:8080/greenhouse with 1 occurrences
* http://www.w3.org/1999/xhtml with 3 occurrences